### PR TITLE
chore: add Windows support for log file open flags

### DIFF
--- a/open_unix.go
+++ b/open_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package seilog
+
+import "syscall"
+
+// noFollowFlag prevents following symlinks at the final path component
+// when opening log files.
+const noFollowFlag = syscall.O_NOFOLLOW

--- a/open_unix_test.go
+++ b/open_unix_test.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package seilog
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestNoFollowFlag(t *testing.T) {
+	if noFollowFlag != syscall.O_NOFOLLOW {
+		t.Fatalf("noFollowFlag = %d, want syscall.O_NOFOLLOW (%d)", noFollowFlag, syscall.O_NOFOLLOW)
+	}
+}

--- a/open_windows.go
+++ b/open_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package seilog
+
+// O_NOFOLLOW is not available on Windows; symlink-following prevention
+// is not applicable on this platform.
+const noFollowFlag = 0

--- a/seilog.go
+++ b/seilog.go
@@ -116,7 +116,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 )
 
 var (
@@ -214,7 +213,7 @@ func openLogFile(p string) (io.WriteCloser, error) {
 	// O_NOFOLLOW prevents opening symlinks at the final path component.
 	// Note: symlinks in parent directories are not checked; the operator
 	// is responsible for ensuring the path is trusted.
-	f, err := os.OpenFile(cleaned, os.O_CREATE|os.O_WRONLY|os.O_APPEND|syscall.O_NOFOLLOW, 0600)
+	f, err := os.OpenFile(cleaned, os.O_CREATE|os.O_WRONLY|os.O_APPEND|noFollowFlag, 0600)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Extract syscall.O_NOFOLLOW into a platform-specific noFollowFlag constant using build-constrained files (open_unix.go, open_windows.go)
- Adds a Unix test asserting noFollowFlag equals syscall.O_NOFOLLOW

This unblocks cross-compilation for Windows consumers of seilog.
[seictl release](https://github.com/sei-protocol/seictl/actions/runs/22828679138/job/66213120428)

## Test plan
- [x] go test ./... passes on darwin
- [x] GOOS=windows GOARCH=amd64 go build ./... cross-compiles successfully